### PR TITLE
Flexible Authentication Hook

### DIFF
--- a/graphqlws/http.go
+++ b/graphqlws/http.go
@@ -34,7 +34,7 @@ func NewHandlerFuncWithAuth(svc connection.GraphQLService, httpHandler http.Hand
 					return
 				}
 
-				go connection.Connect(ws, svc, connection.Authentication(authFunc))
+				go connection.Connect(ws, svc, connection.Authentication(r, authFunc))
 				return
 			}
 		}

--- a/graphqlws/http.go
+++ b/graphqlws/http.go
@@ -1,9 +1,8 @@
 package graphqlws
 
 import (
-	"net/http"
-
 	"github.com/gorilla/websocket"
+	"net/http"
 
 	"github.com/graph-gophers/graphql-transport-ws/graphqlws/internal/connection"
 )
@@ -17,6 +16,11 @@ var upgrader = websocket.Upgrader{
 
 // NewHandlerFunc returns an http.HandlerFunc that supports GraphQL over websockets
 func NewHandlerFunc(svc connection.GraphQLService, httpHandler http.Handler) http.HandlerFunc {
+	return NewHandlerFuncWithAuth(svc, httpHandler, nil)
+}
+
+// NewHandlerFunc returns an http.HandlerFunc that supports GraphQL over websockets
+func NewHandlerFuncWithAuth(svc connection.GraphQLService, httpHandler http.Handler, authFunc connection.AuthenticateFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		for _, subprotocol := range websocket.Subprotocols(r) {
 			if subprotocol == "graphql-ws" {
@@ -30,7 +34,7 @@ func NewHandlerFunc(svc connection.GraphQLService, httpHandler http.Handler) htt
 					return
 				}
 
-				go connection.Connect(ws, svc)
+				go connection.Connect(ws, svc, connection.Authentication(authFunc))
 				return
 			}
 		}

--- a/graphqlws/internal/connection/connection.go
+++ b/graphqlws/internal/connection/connection.go
@@ -47,18 +47,26 @@ type startMessagePayload struct {
 	Variables     map[string]interface{} `json:"variables"`
 }
 
-type initMessagePayload struct{}
-
 // GraphQLService interface
 type GraphQLService interface {
 	Subscribe(ctx context.Context, document string, operationName string, variableValues map[string]interface{}) (payloads <-chan interface{}, err error)
 }
 
+type AuthenticateFunc func(ctx context.Context, payload map[string]interface{}) error
+
 type connection struct {
-	cancel       func()
-	service      GraphQLService
-	writeTimeout time.Duration
-	ws           wsConnection
+	cancel           func()
+	service          GraphQLService
+	writeTimeout     time.Duration
+	ws               wsConnection
+	authenticated    bool
+	authenticateFunc AuthenticateFunc
+}
+
+func Authentication(f AuthenticateFunc) func(conn *connection) {
+	return func(conn *connection) {
+		conn.authenticateFunc = f
+	}
 }
 
 // ReadLimit limits the maximum size of incoming messages
@@ -159,15 +167,31 @@ func (conn *connection) readLoop(ctx context.Context, send sendFunc) {
 
 		switch msg.Type {
 		case typeConnectionInit:
-			var initMsg initMessagePayload
+
+			var initMsg map[string]interface{}
 			if err := json.Unmarshal(msg.Payload, &initMsg); err != nil {
 				ep := errPayload(fmt.Errorf("invalid payload for type: %s", msg.Type))
 				send("", typeConnectionError, ep)
 				continue
 			}
+
+			if conn.authenticateFunc != nil {
+				if err := conn.authenticateFunc(ctx, initMsg); err != nil {
+					send("", typeConnectionError, errPayload(err))
+					continue
+				}
+			}
+			conn.authenticated = true
 			send("", typeConnectionAck, nil)
 
 		case typeStart:
+
+			if !conn.authenticated && conn.authenticateFunc != nil {
+				ep := errPayload(errors.New("authentication required."))
+				send("", typeConnectionError, ep)
+				continue
+			}
+
 			// TODO: check an operation with the same ID hasn't been started already
 			if msg.ID == "" {
 				ep := errPayload(errors.New("missing ID for start operation"))


### PR DESCRIPTION
According to Apollo `Authentication Over WebsSocket` spec (i.e. https://www.apollographql.com/docs/graphql-subscriptions/authentication) the authentication credentials shall be passed in the `connection_init` message payload as `authToken`. 

In order to support this - and - more flexible authentication / authorization schemes which may require inspection of HTTP request headers in addition of the message payload, we add this optional `onConnect` hook.