### PR TITLE
Pass request context to resolvers

### DIFF
--- a/graphqlws/http.go
+++ b/graphqlws/http.go
@@ -30,7 +30,7 @@ func NewHandlerFunc(svc connection.GraphQLService, httpHandler http.Handler) htt
 					return
 				}
 
-				go connection.Connect(ws, svc)
+				go connection.Connect(r.Context(), ws, svc)
 				return
 			}
 		}

--- a/graphqlws/internal/connection/connection.go
+++ b/graphqlws/internal/connection/connection.go
@@ -77,7 +77,7 @@ func WriteTimeout(d time.Duration) func(conn *connection) {
 
 // Connect implements the apollographql subscriptions-transport-ws protocol@v0.9.4
 // https://github.com/apollographql/subscriptions-transport-ws/blob/v0.9.4/PROTOCOL.md
-func Connect(ws wsConnection, service GraphQLService, options ...func(conn *connection)) func() {
+func Connect(ctx context.Context, ws wsConnection, service GraphQLService, options ...func(conn *connection)) func() {
 	conn := &connection{
 		service: service,
 		ws:      ws,
@@ -92,7 +92,7 @@ func Connect(ws wsConnection, service GraphQLService, options ...func(conn *conn
 		opt(conn)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	conn.cancel = cancel
 	conn.readLoop(ctx, conn.writeLoop(ctx))
 

--- a/graphqlws/internal/connection/connection_test.go
+++ b/graphqlws/internal/connection/connection_test.go
@@ -172,7 +172,7 @@ func TestConnect(t *testing.T) {
 	for _, tt := range testTable {
 		t.Run(tt.name, func(t *testing.T) {
 			ws := newConnection()
-			go connection.Connect(ws, tt.svc)
+			go connection.Connect(context.Background(), ws, tt.svc)
 			ws.test(t, tt.messages)
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/graph-gophers/graphql-transport-ws/issues/6