### PR TITLE
Optional function for new context building

### DIFF
--- a/graphqlws/http.go
+++ b/graphqlws/http.go
@@ -16,8 +16,11 @@ var upgrader = websocket.Upgrader{
 	Subprotocols: []string{protocolGraphQLWS},
 }
 
+// ContextBuilderFunc takes a context and the http request which can be used to pull values
+// out of the request context and put into the supplied context.
 type ContextBuilderFunc func(ctx context.Context, r *http.Request) (context.Context, error)
 
+// Option applies configuration when a graphql-ws subprotocol is found
 type Option interface {
 	apply(*options)
 }
@@ -42,6 +45,7 @@ func applyOptions(opts ...Option) *options {
 	return &o
 }
 
+// WithContextBuilder adds a context builder option
 func WithContextBuilder(f ContextBuilderFunc) Option {
 	return optionFunc(func(o *options) {
 		o.contextBuilders = append(o.contextBuilders, f)
@@ -83,4 +87,3 @@ func NewHandlerFunc(svc connection.GraphQLService, httpHandler http.Handler, opt
 		httpHandler.ServeHTTP(w, r)
 	}
 }
-

--- a/graphqlws/http.go
+++ b/graphqlws/http.go
@@ -59,10 +59,11 @@ func NewHandlerFunc(svc connection.GraphQLService, httpHandler http.Handler, opt
 			if subprotocol == "graphql-ws" {
 				o := applyOptions(options...)
 
-				var err error
 				ctx := context.Background()
 				for _, b := range o.contextBuilders {
+					var err error
 					ctx, err = b(ctx, r)
+					http.Error(w, "error test", 403)
 					if err != nil {
 						return
 					}

--- a/graphqlws/http_test.go
+++ b/graphqlws/http_test.go
@@ -54,9 +54,7 @@ func TestContextGenerators(t *testing.T) {
 			t.Parallel()
 
 			req, err := http.NewRequest("GET", "/graphql", nil)
-			if err != nil {
-				return
-			}
+			require.NoError(t, err, "Failed to create request")
 
 			ctx, err := buildContext(req, tt.Args.Generator)
 

--- a/graphqlws/http_test.go
+++ b/graphqlws/http_test.go
@@ -1,0 +1,64 @@
+package graphqlws
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHandlerFunctionalOptions(t *testing.T) {
+	contextBuilderFunc := func() ContextGeneratorFunc {
+		return func(ctx context.Context, r *http.Request) (context.Context, error) {
+			return context.WithValue(ctx, "testKey", "test value"), nil
+		}
+	}
+
+	contextGeneratorOption := WithContextGenerator(contextBuilderFunc())
+
+	type args struct {
+		Options []Option
+	}
+	type want struct {
+		Context context.Context
+		Error error
+	}
+
+	testTable := map[string]struct {
+		Args args
+		Want want
+	}{
+		"No_options": {
+			Args: args{},
+			Want: want{Context: context.Background(), Error: nil},
+		},
+		"With_context_generators": {
+			Args: args{Options: []Option{contextGeneratorOption}},
+			Want: want{Context: context.WithValue(context.Background(), "testKey", "test value"), Error: nil},
+		},
+	}
+
+	for name, tt := range testTable {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest("GET", "/graphql", nil)
+			if err != nil {
+				return
+			}
+
+			ctx, err := processOptions(req, tt.Args.Options...)
+
+			if tt.Want.Error != nil {
+				assert.EqualError(t, tt.Want.Error, err.Error(), "Expected error")
+				return
+			}
+			assert.Equal(t, tt.Want.Context, ctx, "New context generated")
+			require.NoError(t, err, "Error generating context")
+		})
+
+	}
+}

--- a/graphqlws/internal/connection/connection.go
+++ b/graphqlws/internal/connection/connection.go
@@ -77,7 +77,7 @@ func WriteTimeout(d time.Duration) func(conn *connection) {
 
 // Connect implements the apollographql subscriptions-transport-ws protocol@v0.9.4
 // https://github.com/apollographql/subscriptions-transport-ws/blob/v0.9.4/PROTOCOL.md
-func Connect(ws wsConnection, service GraphQLService, options ...func(conn *connection)) func() {
+func Connect(ctx context.Context, ws wsConnection, service GraphQLService, options ...func(conn *connection)) func() {
 	conn := &connection{
 		service: service,
 		ws:      ws,
@@ -92,7 +92,7 @@ func Connect(ws wsConnection, service GraphQLService, options ...func(conn *conn
 		opt(conn)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	conn.cancel = cancel
 	conn.readLoop(ctx, conn.writeLoop(ctx))
 

--- a/graphqlws/internal/connection/connection_test.go
+++ b/graphqlws/internal/connection/connection_test.go
@@ -172,7 +172,8 @@ func TestConnect(t *testing.T) {
 	for _, tt := range testTable {
 		t.Run(tt.name, func(t *testing.T) {
 			ws := newConnection()
-			go connection.Connect(ws, tt.svc)
+
+			go connection.Connect(context.Background(), ws, tt.svc)
 			ws.test(t, tt.messages)
 		})
 	}


### PR DESCRIPTION
Added optional functions to the NewHandlerFunc that let you pull values from the http.Request context and build up a new context that will be supplied to the go routine.