### PR TITLE
Check for err in HTTP handler

### DIFF
--- a/graphqlws/http.go
+++ b/graphqlws/http.go
@@ -97,6 +97,11 @@ func (h *handler) NewHandlerFunc(svc connection.GraphQLService, httpHandler http
 			}
 
 			ctx, err := buildContext(r, o.contextGenerators)
+			if err != nil {
+				w.Header().Set("X-WebSocket-Upgrade-Failure", err.Error())
+				return
+			}
+
 			ws, err := h.Upgrader.Upgrade(w, r, nil)
 			if err != nil {
 				w.Header().Set("X-WebSocket-Upgrade-Failure", err.Error())


### PR DESCRIPTION
Add a error check for the result from buildContext, when buildContext fails, ctx is nil which will panic downstream